### PR TITLE
Implements CLI saveAll command.

### DIFF
--- a/src/WindowResizer.Base/ConfigUtils.cs
+++ b/src/WindowResizer.Base/ConfigUtils.cs
@@ -36,13 +36,13 @@ namespace WindowResizer.Base
 
             try
             {
-                ConfigFactory.Load(configPath);
+                ProfilesFactory.Load(configPath);
             }
             catch (Exception ex)
             {
                 if (ex is System.IO.FileNotFoundException)
                 {
-                    var cnf = Config.NewConfig(profileName);
+                    var cnf = ProfileConfig.NewConfig(profileName);
                 }
                 else
                 {
@@ -51,7 +51,7 @@ namespace WindowResizer.Base
                 }
             }
 
-            ConfigFactory.ConfigPath = configPath;
+            ProfilesFactory.ConfigPath = configPath;
             return true;
         }
 

--- a/src/WindowResizer.Base/ConfigUtils.cs
+++ b/src/WindowResizer.Base/ConfigUtils.cs
@@ -25,5 +25,35 @@ namespace WindowResizer.Base
                 return false;
             }
         }
+
+        public static bool LoadOrCreate(string? configPath, string? profileName, Action<string>? onError)
+        {
+            configPath ??= Path.Combine(
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), nameof(WindowResizer)),
+                DefaultConfigFile);
+
+            profileName ??= string.Empty;
+
+            try
+            {
+                ConfigFactory.Load(configPath);
+            }
+            catch (Exception ex)
+            {
+                if (ex is System.IO.FileNotFoundException)
+                {
+                    var cnf = Config.NewConfig(profileName);
+                }
+                else
+                {
+                    onError?.Invoke("Unexpected error while trying to load config file at \"" + configPath + "\": " + ex.Message);
+                    return false;
+                }
+            }
+
+            ConfigFactory.ConfigPath = configPath;
+            return true;
+        }
+
     }
 }

--- a/src/WindowResizer.Base/WindowCmd.cs
+++ b/src/WindowResizer.Base/WindowCmd.cs
@@ -157,13 +157,13 @@ public static class WindowCmd
         return p;
     }
 
-    private static Config? LoadOrCreateConfig(string? configPath, string? profileName, Action<string>? onError)
+    private static ProfileConfig? LoadOrCreateConfig(string? configPath, string? profileName, Action<string>? onError)
     {
         if (!ConfigUtils.LoadOrCreate(configPath, profileName, onError))
         {
             return null;
         }
 
-        return ConfigFactory.Current;
+        return ProfilesFactory.Current;
     }
 }

--- a/src/WindowResizer.Base/WindowCmd.cs
+++ b/src/WindowResizer.Base/WindowCmd.cs
@@ -75,6 +75,48 @@ public static class WindowCmd
         return true;
     }
 
+    public static bool SaveAll(string? configPath, string? profileName,
+        Action<string>? onError = null,
+        Action<List<TargetWindow>>? onDebug = null)
+    {
+        var profile = LoadOrCreateConfig(configPath, profileName, onError);
+
+        if (profile == null)
+        {
+            return false;
+        }
+
+        profile.WindowSizes.Clear();
+
+        var windows = Resizer.GetOpenWindows();
+        var targets = new List<TargetWindow>();
+
+        foreach (var handle in windows)
+        {
+            if (!IsProcessAvailable(handle, out string processName, null))
+            {
+                continue;
+            }
+
+            var t = Resizer.GetWindowTitle(handle);
+
+            targets.Add(new TargetWindow(handle, processName, t));
+        }
+
+        foreach (var tp in targets)
+        {
+            UpdateOrSaveWindowSize(tp.Handle, profile, (p, e) =>
+            {
+                tp.Result = "Elevated privileges may be required.";
+                onError?.Invoke($"Unable to save position for process <{p}>, elevated privileges may be required.");
+            });
+        }
+
+        onDebug?.Invoke(targets);
+
+        return true;
+    }
+
     public class TargetWindow
     {
         public TargetWindow(IntPtr handle, string processName, string? title)
@@ -113,5 +155,15 @@ public static class WindowCmd
         }
 
         return p;
+    }
+
+    private static Config? LoadOrCreateConfig(string? configPath, string? profileName, Action<string>? onError)
+    {
+        if (!ConfigUtils.LoadOrCreate(configPath, profileName, onError))
+        {
+            return null;
+        }
+
+        return ConfigFactory.Current;
     }
 }

--- a/src/WindowResizer.CLI/Commands/SaveAllCommand.cs
+++ b/src/WindowResizer.CLI/Commands/SaveAllCommand.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using System.Threading.Tasks;
+using Spectre.Console;
+using WindowResizer.Base;
+using WindowResizer.CLI.Utils;
+
+namespace WindowResizer.CLI.Commands
+{
+    internal class SaveAllCommand : Command
+    {
+        public SaveAllCommand() : base("saveAll", "Saves the current position of all open windows.")
+        {
+            var configOption = new ConfigOption();
+            AddOption(configOption);
+            var profileOption = new ProfileOption();
+            AddOption(profileOption);
+            var verboseOption = new VerboseOption();
+            AddOption(verboseOption);
+
+            this.SetHandler((config, profile, verbose) =>
+            {
+                void VerboseInfo(List<WindowCmd.TargetWindow> lists)
+                {
+                    if (verbose)
+                    {
+                        Verbose(lists);
+                    }
+                }
+
+                var success = WindowCmd.SaveAll(config?.FullName, profile, Output.Error, VerboseInfo);
+
+                return Task.FromResult(success ? 0 : 1);
+            }, configOption, profileOption, verboseOption);
+        }
+
+        private static void Verbose(List<WindowCmd.TargetWindow> lists)
+        {
+            if (!lists.Any())
+            {
+                Output.Echo("No windows to be saved.");
+                return;
+            }
+
+            Output.Echo("The following windows were saved:");
+
+            var table = new Table();
+            table.AddColumn(new TableColumn("Handle"));
+            table.AddColumn(new TableColumn("Process"));
+            table.AddColumn(new TableColumn("Title"));
+            table.AddColumn(new TableColumn("Success").Centered());
+            table.AddColumn(new TableColumn("Error"));
+            foreach (var item in lists)
+            {
+                var result = string.IsNullOrEmpty(item.Result) ? "[green]Y[/]" : "[red]N[/]";
+                table.AddRow(item.Handle.ToString(), $"[green]{item.ProcessName}[/]", item.Title ?? string.Empty, result, $"[red]{item.Result}[/]");
+            }
+
+            table.Border(TableBorder.Square);
+            table.Alignment(Justify.Left);
+            AnsiConsole.Write(table);
+        }
+    }
+}

--- a/src/WindowResizer.CLI/Program.cs
+++ b/src/WindowResizer.CLI/Program.cs
@@ -18,6 +18,7 @@ namespace WindowResizer.CLI
 
             var rootCommand = new RootCommand($"{nameof(WindowResizer)} CLI.");
             rootCommand.AddCommand(new ResizeCommand());
+            rootCommand.AddCommand(new SaveAllCommand());
 
             var parser = new CommandLineBuilder(rootCommand)
                          .UseDefaults()


### PR DESCRIPTION
Implementation of what I suggested in #79. But I only implemented "save all", without an option to save a specific window. This shouldn't be very difficult based on the existing resize option.

Now I can script saving and restoring windows. :B

---

This will do the same as the GUI does when using the hotkey or context action to save all open windows' positions.

Usage examples:

WindowResizer.CLI.exe saveAll
WindowResizer.CLI.exe saveAll --config a:\apps\WinResizer\config.json WindowResizer.CLI.exe saveAll --profile CLIPositions

Once saved, to restore them all

WindowResizer.CLI.exe resize

(if a different config file path is used to save, the same must be used to restore).