### PR TITLE
Delays file writes when saving all windows.

### DIFF
--- a/src/WindowResizer.Configuration/ProfilesFactory.cs
+++ b/src/WindowResizer.Configuration/ProfilesFactory.cs
@@ -13,6 +13,7 @@ public static class ProfilesFactory
     private static string _portableConfigPath = string.Empty;
 
     public static bool PortableMode;
+    public static bool PostponeSaving = false;
     public static string ConfigPath = string.Empty;
 
     public static void SetPath(string roamingPath, string portablePath)
@@ -78,7 +79,8 @@ public static class ProfilesFactory
     {
         var json = JsonConvert.SerializeObject(Profiles);
         new FileInfo(ConfigPath).Directory?.Create();
-        File.WriteAllText(ConfigPath, json);
+
+        if (!PostponeSaving) File.WriteAllText(ConfigPath, json);
 
         Profiles.Updated();
     }

--- a/src/WindowResizer/TrayContext.cs
+++ b/src/WindowResizer/TrayContext.cs
@@ -389,6 +389,7 @@ namespace WindowResizer
         private void SaveAll()
         {
             var windows = Resizer.GetOpenWindows();
+            ProfilesFactory.PostponeSaving = true;
             foreach (var window in windows)
             {
                 if (Resizer.GetWindowState(window) != WindowState.Minimized)
@@ -396,6 +397,9 @@ namespace WindowResizer
                     UpdateOrSaveWindowSize(window, ProfilesFactory.Current, null);
                 }
             }
+
+            ProfilesFactory.PostponeSaving = false;
+            ProfilesFactory.Save();
 
             if (ProfilesFactory.Current.NotifyOnSaved)
             {


### PR DESCRIPTION
Avoids truncating and rewriting the json file as many times as there are windows, calling the Save() function only when the list is fully built.

As reported in #81.