### PR TITLE
Clears the list of processes before SaveAll().

### DIFF
--- a/src/WindowResizer/TrayContext.cs
+++ b/src/WindowResizer/TrayContext.cs
@@ -389,6 +389,7 @@ namespace WindowResizer
         private void SaveAll()
         {
             var windows = Resizer.GetOpenWindows();
+            ProfilesFactory.Current.WindowSizes.Clear();
             foreach (var window in windows)
             {
                 if (Resizer.GetWindowState(window) != WindowState.Minimized)


### PR DESCRIPTION
When rebuilding the list of processes from SaveAll(), removes everything to ensure no leftovers.

Without this, minimized windows get restored when calling restore, if they once were not minimized when running a SaveAll().

**Warning:** This might wipe manually configured windows if the user is accustomed to configure inactive windows manually and call SaveAll to save all other windows. It is advised such cases to be saved in different profiles.

To reproduce the issue this (hopefully) fixes:

1. open a window, and trigger SaveAll (hotkey or tray context). Window will be listed in the "Processes" tab.
2. minimize the window and trigger RestoreAll. Window will be restored, as expected.
3. minimize the window again and SaveAll(). The window is still listed in the "Processes" tab.
4. RestoreAll() again -- the minimized window is restored.

With this fix, in step 3, the window will be removed from the list of Processes.

Perhaps a better (much better) fix would be to no longer skip minimized windows, but save their "restored" (non-minimized nor maximized) dimensions _and_ their minimized/maximized **state**, and then also take the state in consideration during restoreAll. When windows are moved to a smaller screen, even if minimized, their sizes are shrunk when restoring them even after the bigger displays have been turned back on.

This might conflict with pr #82, TrayContext.cs:392. In my side I just use the conflicting lines in this sequence:

```
ProfilesFactory.PostponeSaving = true;
ProfilesFactory.Current.WindowSizes.Clear();
```

But the order shouldn't affect anything.